### PR TITLE
Add scenario-based client and server mode examples

### DIFF
--- a/Docs/USAGE.md
+++ b/Docs/USAGE.md
@@ -152,3 +152,19 @@ The `Sample` project strings these concepts together: it authenticates a device,
 * **Intermittent connection drops:** Expect to reconnect if the 20 second timeout in `AnvizStream` elapses. For bulk operations, rely on the retry policy exposed by `UserSynchronizationService`.【F:Anviz.SDK/AnvizStream.cs†L12-L112】【F:Anviz.SDK/Users/UserSynchronizationService.cs†L198-L220】
 
 With these tools you can provision, audit, and synchronise fleets of Anviz devices from a central .NET application.
+
+## 13. Scenario playbooks
+
+The `Sample` project now includes extensible client-mode and server-mode workflows that you can drop into production services or expand with your own business rules.【F:Sample/Program.cs†L1-L119】【F:Sample/Scenarios/ClientModeEnrollmentScenario.cs†L1-L88】【F:Sample/Scenarios/ServerModeRealtimeScenario.cs†L1-L87】 The scenarios share helpers to describe devices, enforce real-time push mode, and subscribe to live events.【F:Sample/Scenarios/ScenarioUtilities.cs†L1-L102】 The following summaries highlight the core building blocks:
+
+### Client mode – enrol users on demand
+
+* `ClientModeEnrollmentScenario` connects to a device, writes `UserInfo` data, optionally captures a fingerprint, and uploads a face template when the hardware supports it.【F:Sample/Scenarios/ClientModeEnrollmentScenario.cs†L31-L81】 You can plug in a `FaceTemplateProvider` that sources templates from disk, a web service, or a camera pipeline.
+* `Program.RunClientModeAsync` shows how to populate the scenario from environment variables, run a post-enrolment hook to fetch incremental attendance, and clear the device cursor once the new punches are processed.【F:Sample/Program.cs†L28-L71】
+
+### Server mode – react to push connections
+
+* `ServerModeRealtimeScenario` listens for inbound sockets, negotiates device capabilities, and keeps each connection alive until a cancellation token or hardware fault ends the session.【F:Sample/Scenarios/ServerModeRealtimeScenario.cs†L23-L87】 Real-time attendance packets are dispatched through a callback, making it easy to enqueue work items or notify downstream systems.
+* `Program.RunServerModeAsync` demonstrates how to spin up the listener alongside a background worker that dequeues live records and performs actions such as opening doors or updating HRIS systems.【F:Sample/Program.cs†L73-L118】 The example also shows how to push configuration—like setting the device clock—whenever a unit connects.
+
+Extend either scenario by supplying new delegates or wrapping them in hosted services: they are intentionally designed around dependency injection-friendly options objects so they stay testable and easy to customise.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ Tested devices
 ## Documentation
 
 - [Usage guide](Docs/USAGE.md) – step-by-step instructions for connecting to devices, managing users and biometrics, and synchronizing multiple terminals.
+- [Scenario playbooks](Docs/USAGE.md#13-scenario-playbooks) – production-ready examples for client polling and server push topologies, including enrolment and real-time automation patterns.

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -1,124 +1,140 @@
-﻿using Anviz.SDK;
+using Anviz.SDK;
+using Anviz.SDK.Responses;
+using Anviz.SDK.Users;
+using Anviz.SDK.Utils;
+using Sample.Scenarios;
+using System.Collections.Concurrent;
 
-namespace Sample
+namespace Sample;
+
+internal static class Program
 {
-    class Program
+    private static async Task Main(string[] args)
     {
-        private const ulong DEVICE_ID = 1;
-        private const string DEVICE_HOST = "10.0.0.1";
-        static async Task Main(string[] args)
+        var manager = new AnvizManager
         {
-            var manager = new AnvizManager();
-#if true //authenticate with device password
-            manager.ConnectionUser = "admin";
-            manager.ConnectionPassword = "12345";
-            manager.AuthenticateConnection = true;
-#endif
-#if true //false for client mode
-            manager.Listen();
-            Console.WriteLine($"Listening on port 5010");
-            using (var device = await manager.Accept())
-#else
-            using (var device = await manager.Connect(DEVICE_HOST))
-#endif
-            {
-                device.DevicePing += (s, e) => Console.WriteLine("Device Ping Received");
-                device.ReceivedPacket += (s, e) => Console.WriteLine("Received packet");
-                device.ReceivedRecord += (s, e) => Console.WriteLine($"Received record {e.DateTime.ToShortTimeString()}");
-                device.DeviceError += (s, e) => throw e;
-                var id = device.DeviceId;
-                var sn = await device.GetDeviceSN();
-                var type = await device.GetDeviceTypeCode();
-                var biotype = await device.GetDeviceBiometricType();
-                Console.WriteLine($"Connected to device {type} ID {id} SN {sn} BIO {biotype}");
-                if (id != DEVICE_ID)
-                {
-                    await device.SetDeviceID(DEVICE_ID);
-                }
-                var now = DateTime.Now;
-                var deviceTime = await device.GetDateTime();
-                Console.WriteLine($"Current device time is {deviceTime.ToShortDateString()} {deviceTime.ToShortTimeString()}");
-                if (Math.Abs((now - deviceTime).TotalSeconds) > 1)
-                {
-                    await device.SetDateTime(now);
-                    Console.WriteLine("Updated device time according to local time");
-                }
-                var net = await device.GetTcpParameters();
-                Console.WriteLine($"Device IP is {net.IP} {net.SubnetMask} {net.DefaultGateway} {net.MacAddress} mode is {net.TcpMode}");
-#if false //here you can change network parameters
-                net.DefaultGateway = IPAddress.Parse("10.0.0.5");
-                await device.SetTCPParameters(net);
-#endif
-                var basic = await device.GetBasicSettings();
-                Console.WriteLine($"FW {basic.Firmware} AdminPWD {basic.ManagementPassword} Vol {basic.Volume} DateFormat {basic.DateFormat} 24h {basic.Is24HourClock}");
-#if false //here you can change basic parameters
-                basic.Volume = Anviz.SDK.Responses.Volume.Off;
-                basic.DateFormat = Anviz.SDK.Responses.DateFormat.DDMMYY;
-                basic.Is24HourClock = true;
-                await device.SetBasicSettings(basic);
-#endif
-                var advanced = await device.GetAdvancedSettings();
-                Console.WriteLine($"FPPrecision {advanced.FPPrecision} Delay {advanced.RepeatAttendanceDelay}");
-#if false //here you can change advanced parameters
-                advanced.FPPrecision = Anviz.SDK.Responses.FPPrecision.Medium;
-                advanced.RepeatAttendanceDelay = 1;
-                await device.SetAdvancedSettings(advanced);
-#endif
-                var card = await device.InquireCard();
-                Console.WriteLine($"Current scanned card: {card}");
-                if (!advanced.RealTimeMode)
-                {
-                    advanced.RealTimeMode = true;
-                    await device.SetAdvancedSettings(advanced);
-                    Console.WriteLine("Enable RealTimeMode");
-                }
-                var stats = await device.GetDownloadInformation();
-                Console.WriteLine($"TotalUsers {stats.UserAmount} TotalRecords {stats.AllRecordAmount}");
-                var employees = await device.GetEmployeesData();
-                var dict = new Dictionary<ulong, string>();
-                foreach (var employee in employees)
-                {
-                    dict.Add(employee.Id, employee.Name);
-                    Console.WriteLine($"Employee {employee.Id} -> {employee.Name} pwd {employee.Password} card {employee.Card} fp {string.Join(", ", employee.EnrolledFingerprints)}");
-                    foreach (var f in employee.EnrolledFingerprints)
-                    {
-                        var fp = await device.GetFingerprintTemplate(employee.Id, f);
-                        Console.WriteLine($"-> {f} {Convert.ToBase64String(fp)}");
-                    }
-                    await device.SetRecords(new Anviz.SDK.Responses.Record(employee.Id));
-                }
-                if (!dict.ContainsValue("TEST"))
-                {
-                    var employee = new Anviz.SDK.Responses.UserInfo(stats.UserAmount + 1, "TEST");
-                    await device.SetEmployeesData(employee);
-                    Console.WriteLine("Created test user, begin fp enroll");
-                    var fp = await device.EnrollFingerprint(employee.Id);
-                    await device.SetFingerprintTemplate(employee.Id, Anviz.SDK.Utils.Finger.RightIndex, fp);
-                }
-                var records = await device.DownloadRecords(true); //true to get only new records
-                foreach (var rec in records)
-                {
-                    Console.WriteLine($"Employee {dict[rec.UserCode]} at {rec.DateTime.ToLongDateString()} {rec.DateTime.ToLongTimeString()}");
-                }
-                await device.ClearNewRecords();
+            ConnectionUser = Environment.GetEnvironmentVariable("ANVIZ_CONNECTION_USER") ?? "admin",
+            ConnectionPassword = Environment.GetEnvironmentVariable("ANVIZ_CONNECTION_PASSWORD") ?? "12345",
+            AuthenticateConnection = true
+        };
 
-                //wait here for RealTime records
-                await Task.Delay(TimeSpan.FromMinutes(5));
-            }
-            Console.ReadLine();
-        }
-
-        public static async void FacepassExample()
+        if (args.Length > 0 && string.Equals(args[0], "server", StringComparison.OrdinalIgnoreCase))
         {
-            var manager = new AnvizManager();
-            ulong employee_id = 5; // number of employee ID, Example 5
-            using (var device = await manager.Accept())
+            await RunServerModeAsync(manager).ConfigureAwait(false);
+        }
+        else
+        {
+            await RunClientModeAsync(manager).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task RunClientModeAsync(AnvizManager manager)
+    {
+        var host = Environment.GetEnvironmentVariable("ANVIZ_DEVICE_HOST") ?? "10.0.0.1";
+        var port = TryParse(Environment.GetEnvironmentVariable("ANVIZ_DEVICE_PORT"), 5010);
+        var userId = (ulong)TryParse(Environment.GetEnvironmentVariable("ANVIZ_USER_ID"), 1001);
+        var userName = Environment.GetEnvironmentVariable("ANVIZ_USER_NAME") ?? "SDK User";
+        var pin = Environment.GetEnvironmentVariable("ANVIZ_USER_PIN");
+        var card = Environment.GetEnvironmentVariable("ANVIZ_USER_CARD");
+
+        var clientOptions = new ClientModeEnrollmentOptions
+        {
+            Host = host,
+            Port = port,
+            UserFactory = () => new UserInfo(userId, userName)
             {
-                var fp = await device.EnrollFingerprint(employee_id, 1);
-                var employee = new Anviz.SDK.Responses.UserInfo(employee_id, "name of employee");
-                await device.SetEmployeesData(employee);
-                await device.SetFaceTemplate(employee.Id, fp);
+                Password = pin,
+                Card = card
+            },
+            FingerSlot = Finger.RightIndex,
+            FingerprintVerificationCount = 2,
+            FaceTemplateProvider = async (device, token) =>
+            {
+                var templatePath = Environment.GetEnvironmentVariable("ANVIZ_FACE_TEMPLATE_PATH");
+                if (string.IsNullOrWhiteSpace(templatePath) || !File.Exists(templatePath))
+                {
+                    return null;
+                }
+
+                var bytes = await File.ReadAllBytesAsync(templatePath, token).ConfigureAwait(false);
+                return new FaceTemplate(bytes);
+            },
+            AfterEnrollment = async (device, profile, token) =>
+            {
+                var records = await device.DownloadRecords(true).ConfigureAwait(false);
+                foreach (var record in records)
+                {
+                    Console.WriteLine($"[CLIENT] Downloaded record for user {record.UserCode} at {record.DateTime:yyyy-MM-dd HH:mm:ss}.");
+                }
+
+                if (records.Count > 0)
+                {
+                    await device.ClearNewRecords().ConfigureAwait(false);
+                }
+            },
+            Log = message => Console.WriteLine($"[CLIENT {DateTime.Now:HH:mm:ss}] {message}")
+        };
+
+        var scenario = new ClientModeEnrollmentScenario(manager, clientOptions);
+        await scenario.RunAsync().ConfigureAwait(false);
+    }
+
+    private static async Task RunServerModeAsync(AnvizManager manager)
+    {
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var recordQueue = new ConcurrentQueue<Record>();
+
+        var serverOptions = new ServerModeOptions
+        {
+            Port = TryParse(Environment.GetEnvironmentVariable("ANVIZ_SERVER_PORT"), 5010),
+            Log = message => Console.WriteLine($"[SERVER {DateTime.Now:HH:mm:ss}] {message}"),
+            OnDeviceConnected = async (device, token) =>
+            {
+                await device.SetDateTime(DateTime.Now).ConfigureAwait(false);
+                await device.SetEmployeesData(new UserInfo(9999, "Visitor") { Password = null, Card = null }).ConfigureAwait(false);
+            },
+            OnRecordReceived = async (record, token) =>
+            {
+                recordQueue.Enqueue(record);
+                await Task.CompletedTask;
+            }
+        };
+
+        var scenario = new ServerModeRealtimeScenario(manager, serverOptions);
+
+        var processor = Task.Run(async () =>
+        {
+            while (!cancellation.Token.IsCancellationRequested)
+            {
+                while (recordQueue.TryDequeue(out var record))
+                {
+                    Console.WriteLine($"[ACTION {DateTime.Now:HH:mm:ss}] Dispatching unlock command for {record.UserCode}.");
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellation.Token).ConfigureAwait(false);
+            }
+        }, cancellation.Token);
+
+        try
+        {
+            await scenario.RunAsync(cancellation.Token).ConfigureAwait(false);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            try
+            {
+                await processor.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when shutting down.
             }
         }
+    }
+
+    private static int TryParse(string? value, int fallback)
+    {
+        return int.TryParse(value, out var parsed) ? parsed : fallback;
     }
 }

--- a/Sample/Scenarios/ClientModeEnrollmentScenario.cs
+++ b/Sample/Scenarios/ClientModeEnrollmentScenario.cs
@@ -1,0 +1,93 @@
+using Anviz.SDK;
+using Anviz.SDK.Responses;
+using Anviz.SDK.Users;
+using Anviz.SDK.Utils;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sample.Scenarios;
+
+internal sealed class ClientModeEnrollmentOptions
+{
+    public required string Host { get; init; }
+    public int Port { get; init; } = 5010;
+    public required Func<UserInfo> UserFactory { get; init; }
+    public bool EnrollFingerprint { get; init; } = true;
+    public Finger FingerSlot { get; init; } = Finger.RightIndex;
+    public int FingerprintVerificationCount { get; init; } = 2;
+    public Func<AnvizDevice, CancellationToken, Task<FaceTemplate?>>? FaceTemplateProvider { get; init; }
+    public Func<AnvizDevice, UserInfo, CancellationToken, Task>? AfterEnrollment { get; init; }
+    public Action<string>? Log { get; init; }
+}
+
+internal sealed class ClientModeEnrollmentScenario
+{
+    private readonly AnvizManager _manager;
+    private readonly ClientModeEnrollmentOptions _options;
+
+    public ClientModeEnrollmentScenario(AnvizManager manager, ClientModeEnrollmentOptions options)
+    {
+        _manager = manager ?? throw new ArgumentNullException(nameof(manager));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _options.Log?.Invoke($"Connecting to {_options.Host}:{_options.Port} (client mode)...");
+        using var device = await _manager.Connect(_options.Host, _options.Port).ConfigureAwait(false);
+
+        var sessionCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscriptions = ScenarioUtilities.AttachLogging(device, _options.Log, null, cancellationToken, sessionCompletion);
+
+        var description = await ScenarioUtilities.DescribeDeviceAsync(device).ConfigureAwait(false);
+        _options.Log?.Invoke($"Connected to {description}");
+
+        await ScenarioUtilities.EnsureRealtimeModeAsync(device, cancellationToken, _options.Log).ConfigureAwait(false);
+
+        var userProfile = _options.UserFactory();
+        _options.Log?.Invoke($"Uploading core user profile {userProfile.Id} – {userProfile.Name}...");
+        await device.SetEmployeesData(userProfile).ConfigureAwait(false);
+
+        if (_options.EnrollFingerprint)
+        {
+            _options.Log?.Invoke($"Enrolling fingerprint for user {userProfile.Id} (verify {_options.FingerprintVerificationCount} times)...");
+            var fingerprintTemplate = await device.EnrollFingerprint(userProfile.Id, _options.FingerprintVerificationCount).ConfigureAwait(false);
+            await device.SetFingerprintTemplate(userProfile.Id, _options.FingerSlot, fingerprintTemplate).ConfigureAwait(false);
+            _options.Log?.Invoke($"Fingerprint stored in slot {_options.FingerSlot}.");
+        }
+
+        if (_options.FaceTemplateProvider != null)
+        {
+            var biometricType = await device.GetDeviceBiometricType().ConfigureAwait(false);
+            if (DeviceCapabilities.SupportsFaceTemplates(biometricType))
+            {
+                _options.Log?.Invoke($"Device supports face templates. Requesting data from provider...");
+                var faceTemplate = await _options.FaceTemplateProvider(device, cancellationToken).ConfigureAwait(false);
+                if (faceTemplate != null)
+                {
+                    await device.SetFaceTemplate(userProfile.Id, faceTemplate).ConfigureAwait(false);
+                    _options.Log?.Invoke("Face template uploaded successfully.");
+                }
+                else
+                {
+                    _options.Log?.Invoke("Face template provider returned no data. Skipping face upload.");
+                }
+            }
+            else
+            {
+                _options.Log?.Invoke("Device does not support face templates. Skipping face upload.");
+            }
+        }
+
+        if (_options.AfterEnrollment != null)
+        {
+            _options.Log?.Invoke("Running post-enrollment hook...");
+            await _options.AfterEnrollment(device, userProfile, cancellationToken).ConfigureAwait(false);
+        }
+
+        _options.Log?.Invoke("Client mode enrollment scenario completed.");
+    }
+}

--- a/Sample/Scenarios/ScenarioUtilities.cs
+++ b/Sample/Scenarios/ScenarioUtilities.cs
@@ -1,0 +1,153 @@
+using Anviz.SDK;
+using Anviz.SDK.Responses;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sample.Scenarios;
+
+internal static class ScenarioUtilities
+{
+    public static async Task<string> DescribeDeviceAsync(AnvizDevice device)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        var deviceId = await device.GetDeviceID().ConfigureAwait(false);
+        var serialNumber = await device.GetDeviceSN().ConfigureAwait(false);
+        var deviceType = await device.GetDeviceTypeCode().ConfigureAwait(false);
+        var biometricType = await device.GetDeviceBiometricType().ConfigureAwait(false);
+
+        return $"ID {deviceId} / SN {serialNumber} / Type {deviceType} / Biometric {biometricType}";
+    }
+
+    public static async Task EnsureRealtimeModeAsync(AnvizDevice device, CancellationToken cancellationToken, Action<string>? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        var advancedSettings = await device.GetAdvancedSettings().ConfigureAwait(false);
+        if (advancedSettings.RealTimeMode)
+        {
+            return;
+        }
+
+        advancedSettings.RealTimeMode = true;
+        await device.SetAdvancedSettings(advancedSettings).ConfigureAwait(false);
+        log?.Invoke("Enabled real-time push mode on device.");
+    }
+
+    public static IDisposable AttachLogging(
+        AnvizDevice device,
+        Action<string>? log,
+        Func<Record, CancellationToken, Task>? onRecord,
+        CancellationToken cancellationToken,
+        TaskCompletionSource<bool>? sessionCompletion = null)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        EventHandler? pingHandler = null;
+        EventHandler<Record>? recordHandler = null;
+        EventHandler<Response>? packetHandler = null;
+        EventHandler<Exception>? errorHandler = null;
+
+        if (log != null)
+        {
+            pingHandler = (_, _) => log("Heartbeat (ping) received from device.");
+            packetHandler = (_, response) => log($"Async packet 0x{response.ResponseCode:X2} ({response.DATA.Length} bytes).");
+        }
+
+        if (onRecord != null || log != null)
+        {
+            recordHandler = (_, record) =>
+            {
+                log?.Invoke($"Real-time record: user {record.UserCode} at {record.DateTime:yyyy-MM-dd HH:mm:ss}.");
+
+                if (onRecord != null)
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await onRecord(record, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            log?.Invoke("Record handler cancelled.");
+                        }
+                        catch (Exception ex)
+                        {
+                            log?.Invoke($"Record handler failed: {ex.Message}");
+                        }
+                    }, CancellationToken.None);
+                }
+            };
+        }
+
+        errorHandler = (_, exception) =>
+        {
+            log?.Invoke($"Device error signalled: {exception.Message}");
+            sessionCompletion?.TrySetResult(false);
+        };
+
+        if (pingHandler != null)
+        {
+            device.DevicePing += pingHandler;
+        }
+
+        if (packetHandler != null)
+        {
+            device.ReceivedPacket += packetHandler;
+        }
+
+        if (recordHandler != null)
+        {
+            device.ReceivedRecord += recordHandler;
+        }
+
+        device.DeviceError += errorHandler;
+
+        return new DelegateDisposable(() =>
+        {
+            if (pingHandler != null)
+            {
+                device.DevicePing -= pingHandler;
+            }
+
+            if (packetHandler != null)
+            {
+                device.ReceivedPacket -= packetHandler;
+            }
+
+            if (recordHandler != null)
+            {
+                device.ReceivedRecord -= recordHandler;
+            }
+
+            if (errorHandler != null)
+            {
+                device.DeviceError -= errorHandler;
+            }
+        });
+    }
+
+    private sealed class DelegateDisposable : IDisposable
+    {
+        private readonly Action _dispose;
+        private bool _disposed;
+
+        public DelegateDisposable(Action dispose)
+        {
+            _dispose = dispose;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _dispose();
+        }
+    }
+}

--- a/Sample/Scenarios/ServerModeRealtimeScenario.cs
+++ b/Sample/Scenarios/ServerModeRealtimeScenario.cs
@@ -1,0 +1,103 @@
+using Anviz.SDK;
+using Anviz.SDK.Responses;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sample.Scenarios;
+
+internal sealed class ServerModeOptions
+{
+    public int Port { get; init; } = 5010;
+    public TimeSpan AcceptPollInterval { get; init; } = TimeSpan.FromMilliseconds(200);
+    public Action<string>? Log { get; init; }
+    public Func<AnvizDevice, CancellationToken, Task>? OnDeviceConnected { get; init; }
+    public Func<Record, CancellationToken, Task>? OnRecordReceived { get; init; }
+}
+
+internal sealed class ServerModeRealtimeScenario
+{
+    private readonly AnvizManager _manager;
+    private readonly ServerModeOptions _options;
+
+    public ServerModeRealtimeScenario(AnvizManager manager, ServerModeOptions options)
+    {
+        _manager = manager ?? throw new ArgumentNullException(nameof(manager));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _manager.Listen(_options.Port);
+        _options.Log?.Invoke($"Listening for device connections on port {_options.Port} (server mode)...");
+
+        using var stopRegistration = cancellationToken.Register(_manager.StopServer);
+        var activeSessions = new List<Task>();
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (!_manager.Pending())
+                {
+                    await Task.Delay(_options.AcceptPollInterval, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                var device = await _manager.Accept().ConfigureAwait(false);
+                activeSessions.Add(HandleDeviceAsync(device, cancellationToken));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _options.Log?.Invoke("Server cancellation requested. Stopping listener...");
+        }
+        finally
+        {
+            _manager.StopServer();
+            if (activeSessions.Count > 0)
+            {
+                await Task.WhenAll(activeSessions).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task HandleDeviceAsync(AnvizDevice device, CancellationToken cancellationToken)
+    {
+        _options.Log?.Invoke("Accepted device connection.");
+
+        using (device)
+        {
+            var sessionCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var subscriptions = ScenarioUtilities.AttachLogging(device, _options.Log, _options.OnRecordReceived, cancellationToken, sessionCompletion);
+
+            try
+            {
+                var description = await ScenarioUtilities.DescribeDeviceAsync(device).ConfigureAwait(false);
+                _options.Log?.Invoke($"Session initialised for {description}");
+
+                await ScenarioUtilities.EnsureRealtimeModeAsync(device, cancellationToken, _options.Log).ConfigureAwait(false);
+
+                if (_options.OnDeviceConnected != null)
+                {
+                    await _options.OnDeviceConnected(device, cancellationToken).ConfigureAwait(false);
+                }
+
+                await sessionCompletion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _options.Log?.Invoke("Ending device session due to cancellation.");
+            }
+            catch (Exception ex)
+            {
+                _options.Log?.Invoke($"Device session faulted: {ex.Message}");
+            }
+        }
+
+        _options.Log?.Invoke("Device session closed.");
+    }
+}


### PR DESCRIPTION
## Summary
- restructure the sample console into client-mode and server-mode workflows backed by configurable options and shared helpers
- document the new scenario playbooks in the usage guide and link them from the README

## Testing
- dotnet build Sample/Sample.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68e0c04903f88326b5bea6886346b169