### PR TITLE
Enable slot-aware biometric enrollment and face sync

### DIFF
--- a/Anviz.SDK/Commands/EnrollFingerprintCommand.cs
+++ b/Anviz.SDK/Commands/EnrollFingerprintCommand.cs
@@ -8,11 +8,11 @@ namespace Anviz.SDK.Commands
     class EnrollFingerprintCommand : Command
     {
         private const byte ENROLL_FINGERPRINT = 0x5C;
-        public EnrollFingerprintCommand(ulong deviceId, ulong employeeID, bool isFirst) : base(deviceId)
+        public EnrollFingerprintCommand(ulong deviceId, ulong employeeID, byte slot, bool isFirst) : base(deviceId)
         {
             var payload = new byte[7];
             Bytes.Write(5, employeeID).CopyTo(payload, 0);
-            payload[5] = 1;
+            payload[5] = slot;
             payload[6] = (byte)(isFirst ? 0 : 1);
             BuildPayload(ENROLL_FINGERPRINT, payload);
         }
@@ -23,7 +23,17 @@ namespace Anviz.SDK
 {
     public partial class AnvizDevice
     {
-        public async Task<byte[]> EnrollFingerprint(ulong employeeID, int verifyCount = 2)
+        public Task<byte[]> EnrollFingerprint(ulong employeeID, int verifyCount = 2)
+        {
+            return EnrollFingerprint(employeeID, Finger.RightThumb, verifyCount);
+        }
+
+        public async Task<byte[]> EnrollFingerprint(ulong employeeID, Finger finger, int verifyCount = 2)
+        {
+            return await EnrollTemplateAsync(employeeID, (byte)(finger + 1), verifyCount).ConfigureAwait(false);
+        }
+
+        public async Task<byte[]> EnrollTemplateAsync(ulong employeeID, byte slot, int verifyCount = 2)
         {
             if (verifyCount < 1)
             {
@@ -32,10 +42,10 @@ namespace Anviz.SDK
             var first = true;
             while (verifyCount-- > 0)
             {
-                await DeviceStream.SendCommand(new EnrollFingerprintCommand(DeviceId, employeeID, first));
+                await DeviceStream.SendCommand(new EnrollFingerprintCommand(DeviceId, employeeID, slot, first)).ConfigureAwait(false);
                 first = false;
             }
-            return await GetFingerprintTemplate(employeeID, 0);
+            return await GetBiometricTemplate(employeeID, slot).ConfigureAwait(false);
         }
     }
 }

--- a/Anviz.SDK/Commands/GetDeviceTypeCommand.cs
+++ b/Anviz.SDK/Commands/GetDeviceTypeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Anviz.SDK.Commands;
+using Anviz.SDK.Users;
 using Anviz.SDK.Utils;
 using System.Threading.Tasks;
 
@@ -29,7 +30,17 @@ namespace Anviz.SDK
         public async Task<BiometricType> GetDeviceBiometricType()
         {
             var code = await GetDeviceTypeCode();
-            DeviceBiometricType = BiometricTypes.DecodeBiometricType(code);
+            var decoded = BiometricTypes.DecodeBiometricType(code);
+            if (decoded == BiometricType.Unknown)
+            {
+                var descriptor = DeviceCapabilities.GetFaceTemplateFormat(code);
+                if (descriptor != DeviceFaceTemplateFormat.Default)
+                {
+                    decoded = BiometricType.Face;
+                }
+            }
+
+            DeviceBiometricType = decoded;
             return DeviceBiometricType;
         }
     }

--- a/Anviz.SDK/Commands/GetFaceTemplateCommand.cs
+++ b/Anviz.SDK/Commands/GetFaceTemplateCommand.cs
@@ -8,11 +8,11 @@ namespace Anviz.SDK.Commands
     class GetFaceTemplateCommand : Command
     {
         private const byte GET_FACETEMPLATE = 0x44;
-        public GetFaceTemplateCommand(ulong deviceId, ulong employeeID) : base(deviceId)
+        public GetFaceTemplateCommand(ulong deviceId, ulong employeeID, byte slot) : base(deviceId)
         {
             var payload = new byte[6];
             Bytes.Write(5, employeeID).CopyTo(payload, 0);
-            payload[5] = 1;
+            payload[5] = slot;
             BuildPayload(GET_FACETEMPLATE, payload);
         }
     }
@@ -24,14 +24,26 @@ namespace Anviz.SDK
     {
         public async Task<byte[]> GetFaceTemplate(ulong employeeID)
         {
-            var response = await DeviceStream.SendCommand(new GetFaceTemplateCommand(DeviceId, employeeID));
+            var descriptor = await EnsureFaceTemplateFormatAsync().ConfigureAwait(false);
+            var response = await DeviceStream.SendCommand(new GetFaceTemplateCommand(DeviceId, employeeID, descriptor.SlotIndex)).ConfigureAwait(false);
             return response.DATA;
         }
 
         public async Task<FaceTemplate> GetFaceTemplateInfo(ulong employeeID)
         {
-            var response = await DeviceStream.SendCommand(new GetFaceTemplateCommand(DeviceId, employeeID));
+            var descriptor = await EnsureFaceTemplateFormatAsync().ConfigureAwait(false);
+            var response = await DeviceStream.SendCommand(new GetFaceTemplateCommand(DeviceId, employeeID, descriptor.SlotIndex)).ConfigureAwait(false);
             return FaceTemplate.FromDevicePayload(response.DATA);
+        }
+
+        private async Task<DeviceFaceTemplateFormat> EnsureFaceTemplateFormatAsync()
+        {
+            if (string.IsNullOrWhiteSpace(DeviceTypeCode))
+            {
+                await GetDeviceTypeCode().ConfigureAwait(false);
+            }
+
+            return DeviceCapabilities.GetFaceTemplateFormat(DeviceTypeCode);
         }
     }
 }

--- a/Anviz.SDK/Commands/GetFingerprintTemplateCommand.cs
+++ b/Anviz.SDK/Commands/GetFingerprintTemplateCommand.cs
@@ -7,11 +7,11 @@ namespace Anviz.SDK.Commands
     class GetFingerprintTemplateCommand : Command
     {
         private const byte GET_FPTEMPLATE = 0x44;
-        public GetFingerprintTemplateCommand(ulong deviceId, ulong employeeID, Finger finger) : base(deviceId)
+        public GetFingerprintTemplateCommand(ulong deviceId, ulong employeeID, byte slot) : base(deviceId)
         {
             var payload = new byte[6];
             Bytes.Write(5, employeeID).CopyTo(payload, 0);
-            payload[5] = (byte)(finger + 1);
+            payload[5] = slot;
             BuildPayload(GET_FPTEMPLATE, payload);
         }
     }
@@ -21,9 +21,14 @@ namespace Anviz.SDK
 {
     public partial class AnvizDevice
     {
-        public async Task<byte[]> GetFingerprintTemplate(ulong employeeID, Finger finger)
+        public Task<byte[]> GetFingerprintTemplate(ulong employeeID, Finger finger)
         {
-            var response = await DeviceStream.SendCommand(new GetFingerprintTemplateCommand(DeviceId, employeeID, finger));
+            return GetBiometricTemplate(employeeID, (byte)(finger + 1));
+        }
+
+        public async Task<byte[]> GetBiometricTemplate(ulong employeeID, byte slot)
+        {
+            var response = await DeviceStream.SendCommand(new GetFingerprintTemplateCommand(DeviceId, employeeID, slot)).ConfigureAwait(false);
             return response.DATA;
         }
     }

--- a/Anviz.SDK/Commands/SetFaceTemplateCommand.cs
+++ b/Anviz.SDK/Commands/SetFaceTemplateCommand.cs
@@ -29,8 +29,8 @@ namespace Anviz.SDK
                 throw new ArgumentNullException(nameof(template));
             }
 
-            var descriptor = format ?? DeviceCapabilities.GetFaceTemplateFormat(DeviceTypeCode);
-            await DeviceStream.SendCommand(new SetFaceTemplateCommand(DeviceId, employeeID, template, descriptor));
+            var descriptor = format ?? await EnsureFaceTemplateFormatAsync().ConfigureAwait(false);
+            await DeviceStream.SendCommand(new SetFaceTemplateCommand(DeviceId, employeeID, template, descriptor)).ConfigureAwait(false);
         }
 
         public async Task SetFaceTemplate(ulong employeeID, byte[] template)
@@ -40,7 +40,9 @@ namespace Anviz.SDK
                 throw new ArgumentNullException(nameof(template));
             }
 
-            await SetFaceTemplate(employeeID, new FaceTemplate(template));
+            var descriptor = await EnsureFaceTemplateFormatAsync().ConfigureAwait(false);
+            var faceTemplate = new FaceTemplate(descriptor.SlotIndex, template);
+            await SetFaceTemplate(employeeID, faceTemplate, descriptor).ConfigureAwait(false);
         }
     }
 }

--- a/Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs
+++ b/Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs
@@ -1,5 +1,6 @@
 ﻿using Anviz.SDK.Commands;
 using Anviz.SDK.Utils;
+using System;
 using System.Threading.Tasks;
 
 namespace Anviz.SDK.Commands
@@ -7,11 +8,16 @@ namespace Anviz.SDK.Commands
     class SetFingerprintTemplateCommand : Command
     {
         private const byte SET_FPTEMPLATE = 0x45;
-        public SetFingerprintTemplateCommand(ulong deviceId, ulong employeeID, Finger finger, byte[] template) : base(deviceId)
+        public SetFingerprintTemplateCommand(ulong deviceId, ulong employeeID, byte slot, byte[] template) : base(deviceId)
         {
-            var payload = new byte[344];
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            var payload = new byte[template.Length + 6];
             Bytes.Write(5, employeeID).CopyTo(payload, 0);
-            payload[5] = (byte)(finger + 1);
+            payload[5] = slot;
             template.CopyTo(payload, 6);
             BuildPayload(SET_FPTEMPLATE, payload);
         }
@@ -22,9 +28,19 @@ namespace Anviz.SDK
 {
     public partial class AnvizDevice
     {
-        public async Task SetFingerprintTemplate(ulong employeeID, Finger finger, byte[] template)
+        public Task SetFingerprintTemplate(ulong employeeID, Finger finger, byte[] template)
         {
-            await DeviceStream.SendCommand(new SetFingerprintTemplateCommand(DeviceId, employeeID, finger, template));
+            return SetBiometricTemplate(employeeID, (byte)(finger + 1), template);
+        }
+
+        public async Task SetBiometricTemplate(ulong employeeID, byte slot, byte[] template)
+        {
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            await DeviceStream.SendCommand(new SetFingerprintTemplateCommand(DeviceId, employeeID, slot, template)).ConfigureAwait(false);
         }
     }
 }

--- a/Anviz.SDK/Users/DeviceFaceTemplateFormat.cs
+++ b/Anviz.SDK/Users/DeviceFaceTemplateFormat.cs
@@ -4,14 +4,15 @@ namespace Anviz.SDK.Users
 {
     public sealed class DeviceFaceTemplateFormat
     {
-        public static DeviceFaceTemplateFormat Default { get; } = new DeviceFaceTemplateFormat(15360, true);
-        public static DeviceFaceTemplateFormat FacePass7 { get; } = new DeviceFaceTemplateFormat(15360, true);
-        public static DeviceFaceTemplateFormat FaceDeep5 { get; } = new DeviceFaceTemplateFormat(15360, true);
+        public static DeviceFaceTemplateFormat Default { get; } = new DeviceFaceTemplateFormat(15360, true, 10);
+        public static DeviceFaceTemplateFormat FacePass7 { get; } = new DeviceFaceTemplateFormat(15360, true, 10);
+        public static DeviceFaceTemplateFormat FaceDeep5 { get; } = new DeviceFaceTemplateFormat(15360, true, 10);
 
         public int TemplateSize { get; }
         public bool RequiresPadding { get; }
+        public byte SlotIndex { get; }
 
-        public DeviceFaceTemplateFormat(int templateSize, bool requiresPadding)
+        public DeviceFaceTemplateFormat(int templateSize, bool requiresPadding, byte slotIndex)
         {
             if (templateSize <= 0)
             {
@@ -20,6 +21,7 @@ namespace Anviz.SDK.Users
 
             TemplateSize = templateSize;
             RequiresPadding = requiresPadding;
+            SlotIndex = slotIndex;
         }
     }
 }

--- a/Anviz.SDK/Users/FaceTemplate.cs
+++ b/Anviz.SDK/Users/FaceTemplate.cs
@@ -11,7 +11,7 @@ namespace Anviz.SDK.Users
         public byte[] Data { get; }
         public string ContentHash { get; }
 
-        public FaceTemplate(byte[] template) : this(1, template)
+        public FaceTemplate(byte[] template) : this(DeviceFaceTemplateFormat.Default.SlotIndex, template)
         {
         }
 

--- a/Anviz.SDK/Users/UserSynchronizationService.cs
+++ b/Anviz.SDK/Users/UserSynchronizationService.cs
@@ -95,7 +95,7 @@ namespace Anviz.SDK.Users
                 await ExecuteWithRetry(async _ => await device.SetEmployeesData(upsertProfiles.Select(profile => profile.CreateDeviceUser()).ToList()), cancellationToken);
             }
 
-            if (DeviceCapabilities.SupportsFaceTemplates(device.DeviceBiometricType))
+            if (DeviceCapabilities.SupportsFaceTemplates(device.DeviceBiometricType, device.DeviceTypeCode))
             {
                 foreach (var profile in centralUsers.Values)
                 {
@@ -110,7 +110,7 @@ namespace Anviz.SDK.Users
 
             await ExecuteWithRetry(async _ => await device.SetEmployeesData(profile.CreateDeviceUser()), cancellationToken);
 
-            if (DeviceCapabilities.SupportsFaceTemplates(device.DeviceBiometricType))
+            if (DeviceCapabilities.SupportsFaceTemplates(device.DeviceBiometricType, device.DeviceTypeCode))
             {
                 await SynchronizeFaceTemplatesAsync(device, profile, cancellationToken);
             }

--- a/Anviz.SDK/Utils/DeviceCapabilities.cs
+++ b/Anviz.SDK/Utils/DeviceCapabilities.cs
@@ -39,9 +39,20 @@ namespace Anviz.SDK.Utils
             return DeviceFaceTemplateFormat.Default;
         }
 
-        public static bool SupportsFaceTemplates(BiometricType biometricType)
+        public static bool SupportsFaceTemplates(BiometricType biometricType, string deviceTypeCode = null)
         {
-            return biometricType == BiometricType.Face;
+            if (biometricType == BiometricType.Face)
+            {
+                return true;
+            }
+
+            if (biometricType == BiometricType.Unknown && !string.IsNullOrWhiteSpace(deviceTypeCode))
+            {
+                var descriptor = GetFaceTemplateFormat(deviceTypeCode);
+                return descriptor != DeviceFaceTemplateFormat.Default;
+            }
+
+            return false;
         }
     }
 }

--- a/Docs/FaceEnrollmentInvestigation.md
+++ b/Docs/FaceEnrollmentInvestigation.md
@@ -1,0 +1,55 @@
+# FaceDeep 5 Face Enrollment Investigation
+
+## Background
+The FaceDeep 5 reports its biometric type as `Unknown` through the current .NET SDK, so `UserSynchronizationService` refuses to
+push face templates even though the hardware is a face terminal.【F:Anviz.SDK/Users/UserSynchronizationService.cs†L98-L156】【F:Anviz.SDK/AnvizDevice.cs†L11-L19】
+While testing, invoking `EnrollFingerprint` on the device unexpectedly opens the face capture workflow on the terminal, which
+suggests the "fingerprint" command can target face slots as well.【F:Anviz.SDK/Commands/EnrollFingerprintCommand.cs†L10-L38】
+
+## What the native SDK exposes
+`crosschex.h` defines the enrolment slot (`backup`) that `CCHex_AddFingerprintOnline` operates on, and it explicitly documents
+that slot values `0-9` represent fingerprints while `10` is the face slot (followed by two iris slots).【F:Docs/crosschex.h†L780-L792】【F:Docs/crosschex.h†L520-L559】
+This means the same command that the .NET SDK names `EnrollFingerprint` is also the documented path for face capture when
+`backup == 10`.
+
+The header also lists multiple fingerprint template sizes (338, 1200, 2048, 6144, 10240, 15360) that different terminals expect
+when templates are uploaded or downloaded.【F:Docs/crosschex.h†L40-L42】
+
+## Behaviour of the current .NET SDK
+The managed `EnrollFingerprintCommand` hard-codes `payload[5] = 1`, so it always requests slot `1` regardless of which biometric
+is required.【F:Anviz.SDK/Commands/EnrollFingerprintCommand.cs†L13-L18】 After the enrolment loop finishes, the SDK reads the
+captured template from slot `0`, which is correct only when you intended to capture the first fingerprint.【F:Anviz.SDK/Commands/EnrollFingerprintCommand.cs†L24-L39】
+`Finger` indices are also limited to the ten fingers, so there is no way to point the command at the face slot (10) or iris slots
+(11 and 12).【F:Anviz.SDK/Utils/Fingers.cs†L40-L75】
+
+Template transport has similar limitations. Both `GetFingerprintTemplate` and `SetFingerprintTemplate` add `1` to the supplied
+finger enum before putting it on the wire, so the only values that can be addressed are `1-10`, and the managed API never exposes
+the constants that would let a caller pick slot `10` for face.【F:Anviz.SDK/Commands/GetFingerprintTemplateCommand.cs†L10-L27】【F:Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs†L10-L27】
+The upload path also fixes the payload size to 344 bytes (6 bytes of metadata + 338 bytes of template data), which matches the
+legacy 338-byte format but not the larger template lengths listed in the native header.【F:Docs/crosschex.h†L40-L42】【F:Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs†L10-L16】
+
+Finally, capability discovery relies solely on the decoded `BiometricType`. The decoder recognises only a handful of device type
+strings and returns `Unknown` for anything else, even if the type code still contains the word "FACE".【F:Anviz.SDK/Utils/BiometricType.cs†L13-L48】
+`DeviceCapabilities.SupportsFaceTemplates` then short-circuits face synchronisation for every `Unknown` device, so a FaceDeep 5
+never receives face uploads even though `DeviceCapabilities` already has heuristics that would recognise its type string.【F:Anviz.SDK/Utils/DeviceCapabilities.cs†L7-L45】【F:Anviz.SDK/Users/UserSynchronizationService.cs†L98-L156】
+
+## Conclusions
+* The protocol explicitly allows slot `10` to drive the face enrolment workflow. The managed SDK needs an API surface that lets
+  callers supply the desired biometric slot instead of hard-coding slot `1`.
+* Template download/upload helpers should be able to address slot `10` (and possibly 11/12) and cope with template buffers larger
+  than 338 bytes to stay compatible with the devices listed in the native header.
+* Biometric capability detection should fall back to parsing the device type code (e.g. check for `FACE` / `FACEDEEP`) so that
+  face synchronisation is not skipped whenever the native code string differs from the hard-coded list in `BiometricTypes`.
+
+Together these gaps explain why the FaceDeep 5 launches its face enrolment UI when `EnrollFingerprint` is invoked yet the SDK
+cannot persist the captured template or treat the unit as a face terminal. Addressing the slot handling and capability detection
+would restore feature parity with the documented native API and improve compatibility with other Anviz devices.
+
+## Remediation
+The SDK now exposes slot-aware helpers so the same enrolment path can target face, fingerprint, or iris slots. `EnrollFingerprint`
+accepts a `Finger` argument and delegates to the new `EnrollTemplateAsync` helper, while the download/upload paths take raw slot
+indices and honour arbitrary template lengths.【F:Anviz.SDK/Commands/EnrollFingerprintCommand.cs†L23-L53】【F:Anviz.SDK/Commands/GetFingerprintTemplateCommand.cs†L10-L34】【F:Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs†L10-L42】
+Face detection no longer depends solely on the decoded `BiometricType`; the SDK falls back to the resolved face template format so
+FaceDeep models correctly advertise face support even when the native type code is unfamiliar.【F:Anviz.SDK/Commands/GetDeviceTypeCommand.cs†L24-L40】【F:Anviz.SDK/Utils/DeviceCapabilities.cs†L25-L53】
+Face template APIs now resolve the device’s slot index before issuing commands, ensuring uploads and downloads target the documented
+face slot (10) instead of the previously hard-coded index `1`.【F:Anviz.SDK/Commands/GetFaceTemplateCommand.cs†L10-L45】【F:Anviz.SDK/Commands/SetFaceTemplateCommand.cs†L23-L53】【F:Anviz.SDK/Users/DeviceFaceTemplateFormat.cs†L5-L23】

--- a/Docs/USAGE.md
+++ b/Docs/USAGE.md
@@ -95,7 +95,7 @@ To quickly inspect a device, run the sample console and follow the prompts. It c
 * `DeleteEmployeesData(ulong id)` removes a user.
 * `SetRecords(Record)` inserts a manual record entry if you need to seed data.【F:Sample/Program.cs†L75-L103】
 
-When enrolling interactively, call `EnrollFingerprint(userId, fingerIndex)`; the result can be saved locally or pushed to other terminals with `SetFingerprintTemplate`.【F:Sample/Program.cs†L92-L97】【F:Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs†L23-L28】
+When enrolling interactively, call `EnrollFingerprint(userId, fingerSlot, verifyCount)`; the result can be saved locally or pushed to other terminals with `SetFingerprintTemplate`.【F:Sample/Scenarios/ClientModeEnrollmentScenario.cs†L54-L70】【F:Anviz.SDK/Commands/SetFingerprintTemplateCommand.cs†L23-L38】
 
 ### Passwords, cards, and fingerprints
 

--- a/Sample/Scenarios/ClientModeEnrollmentScenario.cs
+++ b/Sample/Scenarios/ClientModeEnrollmentScenario.cs
@@ -54,7 +54,7 @@ internal sealed class ClientModeEnrollmentScenario
         if (_options.EnrollFingerprint)
         {
             _options.Log?.Invoke($"Enrolling fingerprint for user {userProfile.Id} (verify {_options.FingerprintVerificationCount} times)...");
-            var fingerprintTemplate = await device.EnrollFingerprint(userProfile.Id, _options.FingerprintVerificationCount).ConfigureAwait(false);
+            var fingerprintTemplate = await device.EnrollFingerprint(userProfile.Id, _options.FingerSlot, _options.FingerprintVerificationCount).ConfigureAwait(false);
             await device.SetFingerprintTemplate(userProfile.Id, _options.FingerSlot, fingerprintTemplate).ConfigureAwait(false);
             _options.Log?.Invoke($"Fingerprint stored in slot {_options.FingerSlot}.");
         }
@@ -62,7 +62,7 @@ internal sealed class ClientModeEnrollmentScenario
         if (_options.FaceTemplateProvider != null)
         {
             var biometricType = await device.GetDeviceBiometricType().ConfigureAwait(false);
-            if (DeviceCapabilities.SupportsFaceTemplates(biometricType))
+            if (DeviceCapabilities.SupportsFaceTemplates(biometricType, device.DeviceTypeCode))
             {
                 _options.Log?.Invoke($"Device supports face templates. Requesting data from provider...");
                 var faceTemplate = await _options.FaceTemplateProvider(device, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add slot-aware enrollment, download, and upload helpers so face templates can be captured through the shared biometric pipeline
- resolve device-specific face template descriptors (including slot index) before reading or writing templates and handle arbitrary payload sizes
- fall back to device type heuristics for face capability detection and update documentation to reflect the new APIs

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e0ca8c81f883268efdd6339b26b627